### PR TITLE
chore: simplify build and workflows

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -4,7 +4,7 @@ inputs:
   npm-script:
     description: 'The name of the npm script to run.'
     required: false
-    default: 'build-demo'
+    default: 'build'
 
 runs:
   using: 'composite'
@@ -13,10 +13,8 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version-file: '.nvmrc'
-        cache: "npm"
     - name: Install dependencies
-      shell: bash
-      run: npm ci
+      uses: bahmutov/npm-install@v1
     - name: Build
       shell: bash
       run: npm run ${{ inputs.npm-script }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,6 @@ jobs:
       - name: Build
         uses: ./.github/actions/build
         with:
-          npm-script: 'ts'
+          npm-script: 'tsc'
       - name: Check
         run: npm test

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -28,8 +28,6 @@ jobs:
       - name: Build
         uses: ./.github/actions/build
         if: github.event.action != 'closed'
-        with:
-          npm-script: 'build-for-surge'
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         if: github.event.action != 'closed'

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The demo is accessible at http://localhost:5173/
 
 The code should be linted with [xo](https://github.com/xojs/xo). To have support in your favorite IDE, see the [how-to used in IDE](https://github.com/xojs/xo#editor-plugins) documentation. 
 
+To lint the code, run `npm run lint`.
+
 
 ## 📃 License
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "xo --fix",
     "preview": "vite preview --base ./",
     "test": "xo",
-    "ts": "tsc"
+    "tsc": "tsc"
   },
   "dependencies": {
     "bpmn-visualization": "~0.32.0"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build-demo": "vite build --base ./",
-    "build-for-surge": "vite build",
+    "build": "vite build --base ./",
     "lint": "xo --fix",
     "preview": "vite preview --base ./",
     "test": "xo",


### PR DESCRIPTION
- Use a more convenient name for the npm script that does TS compilation
- Keep a single build demo npm script for simplificty
- Use the `bahmutov/npm-install` action to manage cache and dependencies install

### Notes

First implemented in https://github.com/process-analytics/bonita-day-demo-2023/pull/7