### PR TITLE
feat: remove reference to mxGraph in the footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>bpmn-visualization demo template</title>
-    <script type="module" src="src/main.ts"></script>
+    <script type="module" src="src/index.ts"></script>
   </head>
   <body>
     <header>

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,5 +44,4 @@ bpmnVisualization.bpmnElementsRegistry.addCssClasses(
 const footer = document.querySelector<HTMLElement>('footer')!;
 const version = bpmnVisualization.getVersion();
 const versionAsString = `bpmn-visualization@${version.lib}`;
-const dependenciesAsString = [...version.dependencies].map(([name, version]) => `${name}@${version}`).join('/');
-footer.textContent = `${versionAsString} with ${dependenciesAsString}`;
+footer.textContent = `${versionAsString}`;


### PR DESCRIPTION
This is not convenient information for users, so remove it.

Also rename `main.ts` into `index.ts` to match common conventions.